### PR TITLE
Redirect if state and local storage don't match

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -14,9 +14,6 @@ import Profile from './pages/Profile';
 import GameSetUp from './pages/GameSetUp';
 import PrivateRoute from './components/PrivateRoute';
 
-
-
-
 const App = () => {
 
   return (
@@ -25,7 +22,7 @@ const App = () => {
         <GameProvider>
           <Navbar />
           <Route exact path="/" component={Home} />
-          <Route path="/wait" component={Wait} />
+          <Route exact path="/wait" component={Wait} />
           <Route exact path="/game" component={Game} />
           <Route exact path="/results" component={GameResults} />
           <Route exact path="/login" component={Login} />

--- a/client/src/components/JoinForm/index.js
+++ b/client/src/components/JoinForm/index.js
@@ -1,4 +1,4 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useGameContext } from '../../utils/GlobalState';
 import { ADD_PLAYER } from '../../utils/actions';

--- a/client/src/components/JoinForm/index.js
+++ b/client/src/components/JoinForm/index.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { useHistory } from 'react-router-dom';
 import { useGameContext } from '../../utils/GlobalState';
 import { ADD_PLAYER } from '../../utils/actions';
@@ -13,8 +13,11 @@ const JoinForm = () => {
     const gameRef = useRef();
     const nameRef = useRef();
     const [state, dispatch] = useGameContext();
-
     let history = useHistory();
+
+    useEffect(() => {
+        localStorage.removeItem('currentGame');
+    }, []);
 
     const handleSubmit = event => {
         event.preventDefault();
@@ -26,6 +29,7 @@ const JoinForm = () => {
             state.icon, 
             state.color)
         .then(result => {
+            localStorage.setItem('currentGame', gameRef.current.value);
             dispatch({
                 type: ADD_PLAYER,
                 post: {

--- a/client/src/components/JoinForm/index.js
+++ b/client/src/components/JoinForm/index.js
@@ -15,13 +15,10 @@ const JoinForm = () => {
     const [state, dispatch] = useGameContext();
     let history = useHistory();
 
-    useEffect(() => {
-        localStorage.removeItem('currentGame');
-    }, []);
-
     const handleSubmit = event => {
         event.preventDefault();
         //TODO: Handle if the quiz code does not match an active quiz
+        localStorage.setItem('currentGame', gameRef.current.value);
         //TODO: Handle if the displayName selected is not unique for this quiz
         API.joinQuiz(
             gameRef.current.value, 
@@ -29,7 +26,6 @@ const JoinForm = () => {
             state.icon, 
             state.color)
         .then(result => {
-            localStorage.setItem('currentGame', gameRef.current.value);
             dispatch({
                 type: ADD_PLAYER,
                 post: {

--- a/client/src/pages/Game.js
+++ b/client/src/pages/Game.js
@@ -23,7 +23,11 @@ const Game = () => {
 
     //this use effect should only run the first time
     useEffect(() => {
-        getQuestion();
+        if(localStorage.currentGame === game){
+            getQuestion();
+        } else {
+            history.push('/');
+        }
     }, []);
 
     //this use effect is listening for events coming from the server

--- a/client/src/pages/GameResults.js
+++ b/client/src/pages/GameResults.js
@@ -1,19 +1,25 @@
 import React, { useEffect, useState } from 'react';
-
+import { Link, useHistory } from 'react-router-dom';
 import { useGameContext } from '../utils/GlobalState';
 import PlayerIcon from '../components/PlayerIcons';
 import Scoreboard from '../components/Scoreboard';
 import API from '../utils/API';
+import Button from '../components/Button';
 
 const GameResults = () => {
     
     const [state, dispatch] = useGameContext();
     const [responded, setScoreboard] = useState('');
     const { game } = state;
+    let history = useHistory();
 
     //this use effect should only run the first time
     useEffect(() => {
-        getWinner();
+        if(localStorage.currentGame === game){
+            getWinner();
+        } else {
+            history.push('/');
+        }
     }, []);
 
     const getWinner = async () => {
@@ -34,6 +40,9 @@ const GameResults = () => {
                 <PlayerIcon icon={responded[0].icon} color={responded[0].color} />
                 <h2>{responded[0].displayName}</h2>
                 <Scoreboard users={responded }/>
+                <Link to="/">
+                    <Button type="button" text="NEW GAME" /> 
+                </Link>
             </>
             : null}
         </div>

--- a/client/src/pages/Wait.js
+++ b/client/src/pages/Wait.js
@@ -25,8 +25,7 @@ const Wait = () => {
                 })
         } else {
             history.push('/');
-        }
-        
+        } 
     }, []);
 
     useEffect(() => {

--- a/client/src/pages/Wait.js
+++ b/client/src/pages/Wait.js
@@ -16,12 +16,17 @@ const Wait = () => {
 
     //general useEffect for first run
     useEffect(() => {
-        ws.emit('join', { game, name, icon, color }, () => {});
-        API.startQuiz(game)
-            .then(result => {
-                console.log("======marked question as started=========")
-                console.log(result);
-            })
+        if(localStorage.currentGame === game){
+            ws.emit('join', { game, name, icon, color }, () => {});
+            API.startQuiz(game)
+                .then(result => {
+                    console.log("======marked question as started=========")
+                    console.log(result);
+                })
+        } else {
+            history.push('/');
+        }
+        
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
To prevent people from jumping in mid-game or winding up on the /wait, /game, or /results page if they are not actively in a game, this PR introduces a very crude redirect to the / if the do not have a (localStorage.currentGame === state.game).

It isn't a very elegant solution because it flashes the page they shouldn't be on - a better solution would be to conditionally render an "oops, you reached a game that is no longer accepting new players" but this is an OK stop gap for now.