### PR TITLE
Refactor how we are handling user responses

### DIFF
--- a/client/src/components/Button/button.css
+++ b/client/src/components/Button/button.css
@@ -7,6 +7,11 @@
     cursor: not-allowed;
 }
 
+.response {
+    background: #9665D8;
+    transition-duration: 0.5s;
+}
+
 .correct {
     opacity: 1;
     background: #03E4AC;

--- a/client/src/components/Button/index.js
+++ b/client/src/components/Button/index.js
@@ -2,11 +2,13 @@ import React from 'react';
 import './button.css';
 
 const Button = (props) => {
+    console.log("==> adding button with id:")
+    console.log(props.id)
     return (
         <button type={props.type ? props.type : 'button'}
             className={props.className ? props.className : null}
             onClick={props.handleClick ? (event) => props.handleClick(event) : null}
-            id={props.id ? props.id : null}
+            id={props.id ? props.id : 0}
             key={props.id ? props.id : null}>
             {props.text}
         </button>

--- a/client/src/components/Button/index.js
+++ b/client/src/components/Button/index.js
@@ -2,8 +2,7 @@ import React from 'react';
 import './button.css';
 
 const Button = (props) => {
-    console.log("==> adding button with id:")
-    console.log(props.id)
+    
     return (
         <button type={props.type ? props.type : 'button'}
             className={props.className ? props.className : null}

--- a/client/src/components/JoinForm/index.js
+++ b/client/src/components/JoinForm/index.js
@@ -8,7 +8,6 @@ import IconPicker from '../IconPicker';
 import ColorPicker from '../ColorPicker';
 
 import "./JoinForm.css";
-import API from '../../utils/API';
 
 const JoinForm = () => {
     const [state, dispatch] = useGameContext();
@@ -35,7 +34,7 @@ const JoinForm = () => {
         });
         //this is the first emit from the client
         //registers the user's socket to this game
-        ws.emit('join', { game: gameCode, name: nameRef.current.value, icon: state.icon, color: state.color }, () => {
+        ws.emit('join', { game: gameCode, userId: state.id, name: nameRef.current.value, icon: state.icon, color: state.color }, () => {
             //TODO: this should handle if someone is already using this name
         });
         //this pushes the player to the wait screen

--- a/client/src/pages/Game.js
+++ b/client/src/pages/Game.js
@@ -60,8 +60,6 @@ const Game = () => {
         //when someone responds, change the state of the scoreboard
         //and pass array of responses
          ws.on('respData', ({ callback }) => {
-           console.log("==> respData received")
-           console.log(callback);
            setScoreboard(callback);
         })
 
@@ -87,8 +85,7 @@ const Game = () => {
 
     const handleResponse = event => {
         let correct; 
-        console.log("==> game.js handle response")
-        console.log(event.target.id);
+        
         if(parseInt(event.target.id) === parseInt(ques.correctIndex)){
             correct = true;
         } else {

--- a/client/src/utils/API.js
+++ b/client/src/utils/API.js
@@ -56,9 +56,8 @@ export default {
         return axios.get(`/api/quiz/question/${game}`);
     },
 
-    saveResponse: (game, displayName, icon, color, correct) => {
-        console.log("======saveResponse======");
-        return axios.post(`/api/quiz/response/${game}`, { displayName, icon, color, correct });
+    saveResponse: (game, userId, displayName, icon, color, questionId, correct) => {
+        return axios.post(`/api/quiz/response/${game}`, { userId, displayName, icon, color, questionId, correct });
     },
 
     getScores: (game) => {

--- a/controllers/gameController.js
+++ b/controllers/gameController.js
@@ -43,4 +43,84 @@ const getQuestionId = async (quizId, qNum, callback) => {
     })
 }
 
-module.exports = { getQuizId, getQuestionId, getQuestion }
+const getResponses = async (quizId, questionId, callback) =>{
+    await db.QuizScore.findAll({
+        where: {
+            quizId,
+            questionId
+        },
+        order: [['updatedAt', 'DESC']]
+    }).then(result => {
+        return callback(result);
+    }).catch(err => {
+        next(err);
+    })
+}
+
+const recordResponse = async (quizCode, userId, displayName, icon, color, questionId, correct, callback) => {
+    let quizId;
+    let name = displayName.toUpperCase();
+    if (!userId) {
+        userId = 999999999;
+    }
+    
+    await getQuizId(quizCode, res => {
+        quizId = res.quizId
+    });
+    //look for a response from this user
+    await db.QuizScore.findOne({
+        where: {
+            quizId, 
+            userId,
+            questionId,
+            displayName: name,
+            icon,
+            color
+        }
+    }).then(result => {
+        if (!result) {
+            //if no record exists, create one
+            db.QuizScore.create({
+                quizId,
+                userId,
+                questionId,
+                displayName: name,
+                icon,
+                color,
+                correct
+            }).then(result => {
+                console.log("new response created");
+                console.log(result)
+                getResponses(quizId, questionId, res => {
+                    return callback(res)
+                });
+            }).catch(err => {
+                console.log(err);
+            })
+        } else {
+            //if a record already exists, update it
+            db.QuizScore.update(
+                {correct: correct},
+                {where: {
+                    quizId,
+                    userId,
+                    questionId,
+                    displayName: name
+                }
+            }).then(result => {
+                console.log("response updated");
+                console.log(result);
+                getResponses(quizId, questionId, res => {
+                    return callback(res)
+                });
+            }).catch(err => {
+                console.log(err);
+            })
+        }
+        
+    }).catch(err => {
+        next(err);
+    })
+}
+
+module.exports = { getQuizId, getQuestionId, getQuestion, recordResponse }

--- a/controllers/sockets.js
+++ b/controllers/sockets.js
@@ -22,13 +22,6 @@ module.exports = (io) => {
             
         })
     
-        // socket.on('response', async ({ game }, callback) => {
-        // //get the user from the server based on the socket id
-        // const user = await getUser(socket.id);
-    
-        // io.to(user.game).emit('respData', {game: user.game});
-        // })
-    
         socket.on("startquestion", async ({ game }, callback) => {
         const user = await getUser(socket.id);
         //create a new roomTimer if there isn't already one active

--- a/controllers/sockets.js
+++ b/controllers/sockets.js
@@ -22,12 +22,6 @@ module.exports = (io) => {
             
         })
     
-        socket.on("startquestion", async ({ game }, callback) => {
-        const user = await getUser(socket.id);
-        //create a new roomTimer if there isn't already one active
-        roomTimer(user.game, "question", io);
-        })
-    
         socket.on('scoringComplete', async ({ game }, callback) => {
         const user = await getUser(socket.id);
         console.log(`Scoring is complete - socketid: ${socket.id}`)

--- a/controllers/sockets.js
+++ b/controllers/sockets.js
@@ -7,10 +7,10 @@ module.exports = (io) => {
     // Set up socket handlers
     io.on('connect', (socket) => {
 
-        socket.on('join', async ({ game, name, icon, color }, callback) => {
+        socket.on('join', async ({ game, userId, name, icon, color }, callback) => {
             console.log(`Socket id on join: ${socket.id}`);
             //creates a record of which socket belongs to this user
-            const { error, user } = await addUser({ id: socket.id, game, name, icon, color })
+            const { error, user } = await addUser({ id: socket.id, game, userId, name, icon, color })
             //throws error if someone in the game
             //is already using this name
             if(error) return callback(error);
@@ -22,12 +22,12 @@ module.exports = (io) => {
             
         })
     
-        socket.on('response', async ({ game }, callback) => {
-        //get the user from the server based on the socket id
-        const user = await getUser(socket.id);
+        // socket.on('response', async ({ game }, callback) => {
+        // //get the user from the server based on the socket id
+        // const user = await getUser(socket.id);
     
-        io.to(user.game).emit('respData', {game: user.game});
-        })
+        // io.to(user.game).emit('respData', {game: user.game});
+        // })
     
         socket.on("startquestion", async ({ game }, callback) => {
         const user = await getUser(socket.id);

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -2,17 +2,20 @@ const users = [];
 const db = require('../models');
 const { getQuizId, getQuestionId } = require('./gameController');
 
-const addUser = async ({ id, game, name, icon, color }, cb) => {
-    name = name.trim().toLowerCase();
-    game = game.trim().toLowerCase();
-
+const addUser = async ({ id, game, userId, name, icon, color }, cb) => {
+    name = name.trim().toUpperCase();
+    game = game.trim().toUpperCase();
+    if (!userId) {
+        userId = 999999999;
+    }
+    
     const existingUser = users.find((user) => user.game === game && user.name === name);
 
     if(existingUser){
         return { error: 'That username is already taken in this game!'}
     }
 
-    const user = { id, game, name, icon, color };
+    const user = { id, game, userId, name, icon, color };
 
     users.push(user);
     
@@ -26,9 +29,12 @@ const addUser = async ({ id, game, name, icon, color }, cb) => {
     await getQuestionId(quizId, 1, res => {
         questionId = res.questionId;
     });
-    
+    //creates the first score value for the user
+    //we use this to populate the waiting room
+    //with users that are in the game
     await db.QuizScore.create({
         quizId,
+        userId,
         questionId,
         displayName: name,
         icon,

--- a/routes/api-routes.js
+++ b/routes/api-routes.js
@@ -114,8 +114,8 @@ module.exports = function (app) {
         });
         db.QuizQuestionsAssoc.bulkCreate(associations)
           .then(response => {
-              console.log("response from bulkCreate: ", response));
-          }
+              console.log("response from bulkCreate: ", response);
+          })
 
       });
     return;

--- a/routes/game-routes.js
+++ b/routes/game-routes.js
@@ -1,6 +1,6 @@
 const db = require('../models');
 const { getQuestion, recordResponse } = require('../controllers/gameController');
-
+const { roomTimer } = require("../controllers/roomTimer");
 module.exports = (app, io) => {
 
     app.io = io;
@@ -49,7 +49,8 @@ module.exports = (app, io) => {
                 req.app.io.to(req.params.quizCode).emit('startGame')
                 getQuestion(req.params.quizCode, callback => {
                     req.app.io.to(req.params.quizCode).emit('showQuestion', { newquestion: callback });
-                })
+                    roomTimer(req.params.quizCode, "question", req.app.io)
+                });
             }).catch(err => {
                 next(err);
             })

--- a/routes/game-routes.js
+++ b/routes/game-routes.js
@@ -87,8 +87,6 @@ module.exports = (app, io) => {
         console.log("post /api/quiz/response/:quizCode " + req.params.quizCode)
         const { userId, displayName, icon, color, questionId, correct } = req.body;
         await recordResponse(req.params.quizCode, userId, displayName, icon, color, questionId, correct, callback => {
-            console.log("==> recordResponse returns");
-            console.log(callback);
             req.app.io.to(req.params.quizCode).emit('respData', { callback });
         })
     })


### PR DESCRIPTION
This PR refactors how we handle user responses. Here's what's changed:

- Clicking the response now triggers an API call instead of a socket
- userId is now passed with the response (if not logged in, userId of 999999999 is assigned)
- we now assert the displayName to all caps (this ensured we didn't run in to caps/no caps conflicts in usernames)
- The route emits a socket to tell all connected clients to update the scoreboard after each response
- User's response is now properly highlighted after it is clicked
- Another socket bites the dust :wink:
- The roomTimer is now triggered when the game is started

@sjmarsnc I ended up adding the userId in quizScores in an attempt to fix a bug in the scoreboard. It is mostly fixed now. More info below:

One remaining problem is that when the first person responds to the first question, everyone shows up as having responded, even if they haven't answered it yet. This is because of the way we are adding people to the waiting room. In order to have them "join" the game, we create their first quizScore record. We are pulling an array of those users to show who has responded, but we don't know if they've actually responded or not. 

The easiest way to get around this would be to change the quizScores model so that we have 3 potential values - something like: correct, incorrect, notanswered.

Without changing any tables, my only other idea is have it check whether createdAt and updatedAt are different for the first question. I'm punting on this for now to focus on the rest of the socket refactor, but I'll come back to it.