### PR TITLE
Display a countdown screen before the quiz starts

### DIFF
--- a/client/src/components/Countdown/countdown.css
+++ b/client/src/components/Countdown/countdown.css
@@ -1,0 +1,5 @@
+.countdowntext {
+    width: 90px;
+    font-size: 50px;
+    margin: 10px auto;
+}

--- a/client/src/components/Countdown/index.js
+++ b/client/src/components/Countdown/index.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+
+import './countdown.css';
+
+
+const Countdown = (props) => {
+    const { timer } = props;
+
+    useEffect(() => {
+        console.log('use effect for countdown triggered');
+        console.log(timer);
+    }, [timer]);
+
+    return (
+        <>
+            <h2>Your game will begin in ...</h2>
+            <div className="countdowntext">{timer}</div>
+        </>
+    )
+}
+
+export default Countdown;

--- a/controllers/roomTimer.js
+++ b/controllers/roomTimer.js
@@ -36,5 +36,20 @@ const pauseTimer = (game, progress, io) => {
     }, totalTime)
 }
 
-module.exports = { roomTimer };
+const readyTimer = async (game, io) => {
+    let totalTime = 6000;
+    let timerValue = 5;
+
+    let timer = setInterval(() => {
+        timerValue --;
+        io.to(game).emit('getReady', { text: timerValue})
+    }, 1000);
+
+    setTimeout(() => {
+        clearInterval(timer);
+        roomTimer(game, io);
+    }, totalTime)
+}
+
+module.exports = { readyTimer };
 

--- a/routes/game-routes.js
+++ b/routes/game-routes.js
@@ -1,6 +1,6 @@
 const db = require('../models');
-const { startQuiz, calcScores, recordResponse } = require('../controllers/gameController');
-const { roomTimer } = require("../controllers/roomTimer");
+const { startQuiz, recordResponse } = require('../controllers/gameController');
+const { readyTimer } = require("../controllers/roomTimer");
 module.exports = (app, io) => {
 
     app.io = io;
@@ -21,7 +21,9 @@ module.exports = (app, io) => {
         await startQuiz(req.params.quizCode, resp => {
             req.app.io.to(req.params.quizCode).emit('startGame')
         })
-        await roomTimer(req.params.quizCode, req.app.io);
+        //add a pause to ensure everyone is on /game
+        //before the first q is sent
+        await readyTimer(req.params.quizCode, req.app.io);
         return; 
     }) 
 


### PR DESCRIPTION
This PR adds a quick and dirty countdown screen to the beginning of the game. This screen serves two purposes:

1. It is a gentler transition into the game. Only one user clicks the "Everyone is here" button. So we want users to have some warning before we throw the first question at them.
2. It also helps us prevent a race condition where some users were receiving the first question before they had actually been pushed to the /game page. This meant the first question didn't show up for them. This adds a delay to ensure everyone is on the /game page before we send the first question.