### PR TITLE
Make selected icon and color more obvious

### DIFF
--- a/client/src/components/IconPicker/index.js
+++ b/client/src/components/IconPicker/index.js
@@ -39,7 +39,7 @@ const IconPicker = () => {
                     <div className="icon-choice" key={icon.name}>
                         <input type="radio" name="icon" id={icon.name} value={icon.name} onClick={event => toggleIcon(event)} />
                         <label>
-                            <PlayerIcons icon={icon.name} color='#04D5FB' />
+                            <PlayerIcons icon={icon.name} color={state.icon === icon.name ? state.color : '#DEDEDE'} />
                         </label>
                     </div>
                 )


### PR DESCRIPTION
When joining a game, it is difficult to see what options you previously selected for icon and color. This PR is really small, but it accomplishes the following:

1. All the icons in the icon picker first appear as a light grey.
2. When an icon is selected, it changes to the default color (the blue).
3. When a color is selected in the color picker, it changes the color of the icon selected in the icon picker. 
4. If the user doesn't pick anything, their icon will default to the blue throughout the game and no color value will be saved in the db - I tested this and it didn't break anything.