### PR TITLE
Replace html entities in question and responses 

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -4574,9 +4574,9 @@
       }
     },
     "entities": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.2.tgz",
-      "integrity": "sha512-dmD3AvJQBUjKpcNkoqr+x+IF0SdRtPz9Vk0uTy4yWqga9ibB6s4v++QFWNohjiUGoMlF552ZvNyXDxz5iW0qmw=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
     },
     "errno": {
       "version": "0.1.7",

--- a/client/package.json
+++ b/client/package.json
@@ -5,6 +5,7 @@
   "proxy": "http://localhost:3001/",
   "dependencies": {
     "axios": "^0.19.2",
+    "entities": "^2.0.3",
     "jwt-decode": "^2.2.0",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/client/src/components/QText/index.js
+++ b/client/src/components/QText/index.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import { decodeHTML } from 'entities';
 import './qtext.css';
 
 const QText = (props) => {
     return (
         <div className="qbox">
-            <span className="qtext">{props.text}</span>
+            <span className="qtext">{decodeHTML(props.text)}</span>
         </div>
     )
 }

--- a/client/src/pages/Game.js
+++ b/client/src/pages/Game.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { decodeHTML } from 'entities';
 import { useHistory } from 'react-router-dom';
 import { ws } from '../components/socket';
 import { SET_SCORES } from '../utils/actions';
@@ -114,7 +115,7 @@ const Game = () => {
                                     return (
                                         <Button 
                                             className={`gamebutton ${parseInt(sel.response) === parseInt(index) ? 'response' : ''} ${scoring ? `disabled ${index == ques.correctIndex ? 'correct' : ''}` : ''}`}
-                                            text={resp} 
+                                            text={decodeHTML(resp)} 
                                             handleClick={!scoring ? (event) => handleResponse(event) : null }
                                             id={index}
                                             key={index}


### PR DESCRIPTION
This PR fixes the issue where html entities were being displayed in the question and response text. This happens because React automatically escapes the html in JSX to prevent XSS. This little library replaces the html entities with unicode.

I've only used it in the game so far since the html entities are all coming from the questions imported from the API. We may decide we need to use it elsewhere but it is pretty easy to add.