### PR TITLE
update scoreboard for better ux

### DIFF
--- a/client/src/components/Scoreboard/index.js
+++ b/client/src/components/Scoreboard/index.js
@@ -1,14 +1,17 @@
 import React, { useEffect } from 'react';
 import PlayerIcon from '../PlayerIcons';
+import { useGameContext } from '../../utils/GlobalState';
 import './scoreboard.css';
 
 const Scoreboard = (props) => {
-    const { users } = props;
+
+    const [state, dispatch] = useGameContext();
+    const { users, scores, responses } = state;
 
     useEffect(() => {
-        console.log('use effect for scoreboard triggered');
-        console.log(props.users);
-    }, [users]);
+        console.log('==> scoreboard useEffect triggered');
+        console.log(scores);
+    }, [scores]);
 
     return (
         <div className="score-board">
@@ -18,10 +21,13 @@ const Scoreboard = (props) => {
             {users
                 ? (
                     <div>
-                        {users.map(({ displayName, icon, color, score }, index) => {
+                        {users.map(({ displayName, icon, color }, index) => {
+                            let score = 0;
+                            let resp = 'no-resp';
 
-                            if (!score) {
-                                score = 0;
+                            if (scores.length !== 0) {
+                                let userscore = scores.filter(score => score.displayName === displayName);
+                                score = userscore[0].score;
                             }
                             
                             var scoreTrackStyles = {
@@ -29,11 +35,18 @@ const Scoreboard = (props) => {
                                 width: `${score}%`
                             }
 
+                            if(responses.length !== 0) {
+                                let userresponse = responses.filter(response => response.displayName === displayName);
+                                if (userresponse.length > 0){
+                                    resp = 'resp';
+                                }
+                            }
+
                             return (
                                 <div className="scores">
                                     <div className="player-section">
                                         <div className="player-name"> {displayName} </div>
-                                        <div className="player-icon-container">
+                                        <div className={`player-icon-container ${resp}`}>
                                             <div className="player-icon-position" style={scoreTrackStyles}>
                                                 <PlayerIcon icon={icon} color={color} />
                                             </div>

--- a/client/src/components/Scoreboard/scoreboard.css
+++ b/client/src/components/Scoreboard/scoreboard.css
@@ -41,3 +41,11 @@
     right: 50px;
     top: -25px;
 }
+
+.no-resp {
+    opacity: 50%;
+}
+
+.resp {
+    opacity: 100%;
+}

--- a/client/src/pages/Game.js
+++ b/client/src/pages/Game.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { decodeHTML } from 'entities';
 import { useHistory } from 'react-router-dom';
 import { ws } from '../components/socket';
-import { SET_SCORES } from '../utils/actions';
+import { SET_SCORES, SET_RESPONSES } from '../utils/actions';
 
 import Timer from '../components/Timer';
 import Countdown from '../components/Countdown';
@@ -19,7 +19,8 @@ const Game = () => {
     const [gameready, setReady] = useState(false);
     const [count, setCountdown] = useState();
     const [sel, setSelected] = useState();
-    const [responded, setScoreboard] = useState([]);
+    const [response, setResponses] = useState();
+    const [score, setScoreboard] = useState([]);
     const [ques, setQuestion] = useState();
     const [scoring, setScoring] = useState(false);
     let history = useHistory();
@@ -52,6 +53,12 @@ const Game = () => {
                 //only update state if it is a new question
                 if(!ques || ques.questionId !== questionId){
                     setScoring(false);
+                    dispatch({
+                        type: SET_RESPONSES,
+                        post: {
+                            responses: []
+                        }
+                    })
                     setSelected({
                         questionId,
                         response: ''
@@ -68,7 +75,14 @@ const Game = () => {
         //when someone responds, change the state of the scoreboard
         //and pass array of responses
          ws.on('respData', ({ callback }) => {
-           setScoreboard(callback);
+            dispatch({
+                type: SET_RESPONSES,
+                post: {
+                    responses: callback
+                }
+            })
+            setResponses(callback);
+
         })
 
         //show the correct response
@@ -125,7 +139,7 @@ const Game = () => {
                                 : null
                                 }
                         {/* Pass an array of user objects showing everyone in the game: name, icon, color, responded (T/F), %Correct */}
-                        <Scoreboard users={responded ? responded : null}/>
+                        <Scoreboard scores={score ? score : null} responses={response ? response : null}/>
                     </>
             : <Countdown timer={count} />
             }

--- a/client/src/utils/GlobalState.js
+++ b/client/src/utils/GlobalState.js
@@ -1,5 +1,5 @@
 import React, { createContext, useReducer, useContext } from 'react';
-import { SET_COLOR, SET_ICON, SET_USERS, SET_SCORES, ADD_PLAYER, ADD_USER, ADD_GAME } from './actions';
+import { SET_COLOR, SET_ICON, SET_USERS, SET_SCORES, ADD_PLAYER, ADD_USER, ADD_GAME, SET_RESPONSES } from './actions';
 
 const GameContext = createContext();
 const { Provider } = GameContext;
@@ -25,6 +25,11 @@ const reducer = (state, action) => {
             return {
                 ...state,
                 scores: action.post.scores
+            };
+        case SET_RESPONSES:
+            return {
+                ...state,
+                responses: action.post.responses
             };
         case ADD_PLAYER:
             return {
@@ -62,7 +67,8 @@ const GameProvider = ({ value = [], ...props }) => {
         color: '',
         auth: false,
         users: [],
-        scores: []
+        scores: [],
+        responses: []
     });
     console.log("==============state================");
     console.log(state);

--- a/client/src/utils/actions.js
+++ b/client/src/utils/actions.js
@@ -2,6 +2,7 @@ export const SET_ICON = "SET_ICON";
 export const SET_COLOR = "SET_COLOR";
 export const SET_USERS = "SET_USERS";
 export const SET_SCORES = "SET_SCORES";
+export const SET_RESPONSES = "SET_RESPONSES";
 
 export const ADD_GAME = "ADD_GAME";
 export const ADD_PLAYER = "ADD_PLAYER";


### PR DESCRIPTION
Yay! The scoreboard now behaves as follows:

- all users show up on the scoreboard all the time
- when a question is first displayed, the user opacity is set to 50%
- when a user has responded, the user opacity changes to 100%
- when we score the questions, the user moves to their new position on the board

The only remaining gotcha is the first question - which we can only solve by adding null as a value on the quizScores table;